### PR TITLE
incorrect-fsf-address

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
 		       Version 2, June 1991
 
  Copyright (C) 1991 Free Software Foundation, Inc.
-    		    59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    		    51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -464,8 +464,8 @@ convey the exclusion of warranty; and each file should have at least the
 
     You should have received a copy of the GNU Library General Public
     License along with this library; if not, write to the 
-    Free Software Foundation, Inc., 59 Temple Place - Suite 330, 
-    Boston, MA  02111-1307  USA.
+    Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+    Boston, MA  02110-1301  USA.
 
 Also add information on how to contact you by electronic and paper mail.
 


### PR DESCRIPTION
before

[rave@mother ~]$ rpmlint /home/rave/rpmbuild/RPMS/x86_64/mate-dialogs-1.4.0-5.fc16.x86_64.rpm
mate-dialogs.x86_64: W: spelling-error %description -l en_US gdialog -> dialog, g dialog, dialing
mate-dialogs.x86_64: W: spelling-error %description -l en_US cdialog -> dialog, c dialog
mate-dialogs.x86_64: E: description-line-too-long C mate-dialogs lets you display Gtk+ dialog boxes from the command line and through
mate-dialogs.x86_64: W: invalid-url URL: http://mate-desktop.or <urlopen error [Errno -2] Name or service not known>
mate-dialogs.x86_64: E: incorrect-fsf-address /usr/share/doc/mate-dialogs-1.4.0/COPYING
1 packages and 0 specfiles checked; 2 errors, 3 warnings.

after

[rave@mother ~]$ rpmlint /home/rave/rpmbuild/RPMS/x86_64/mate-dialogs-1.4.0-5.fc16.x86_64.rpm
mate-dialogs.x86_64: W: spelling-error %description -l en_US gdialog -> dialog, g dialog, dialing
mate-dialogs.x86_64: W: spelling-error %description -l en_US cdialog -> dialog, c dialog
mate-dialogs.x86_64: E: description-line-too-long C mate-dialogs lets you display Gtk+ dialog boxes from the command line and through
mate-dialogs.x86_64: W: invalid-url URL: http://mate-desktop.or <urlopen error [Errno -2] Name or service not known>
1 packages and 0 specfiles checked; 1 errors, 3 warnings.

Only the incorrect url i didn't found in any file of the source code.

Maybe you're more lucky than me
