### PR TITLE
Fix deprecation

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -18,7 +18,7 @@ IT_PROG_INTLTOOL([0.40.0])
 
 AC_PROG_CC
 
-GTK_REQUIRED=2.18.0
+GTK_REQUIRED=2.24.0
 
 AC_MSG_CHECKING([which gtk+ version to compile against])
 AC_ARG_WITH([gtk],
@@ -32,7 +32,7 @@ AC_MSG_RESULT([$with_gtk])
 
 case "$with_gtk" in
   2.0) GTK_API_VERSION=2.0
-       GTK_REQUIRED=2.18.0
+       GTK_REQUIRED=2.24.0
        ;;
   3.0) GTK_API_VERSION=3.0
        GTK_REQUIRED=2.90.4

--- a/configure.in
+++ b/configure.in
@@ -18,7 +18,7 @@ IT_PROG_INTLTOOL([0.40.0])
 
 AC_PROG_CC
 
-GTK_REQUIRED=2.24.0
+GTK_REQUIRED=2.18.0
 
 AC_MSG_CHECKING([which gtk+ version to compile against])
 AC_ARG_WITH([gtk],
@@ -32,7 +32,7 @@ AC_MSG_RESULT([$with_gtk])
 
 case "$with_gtk" in
   2.0) GTK_API_VERSION=2.0
-       GTK_REQUIRED=2.24.0
+       GTK_REQUIRED=2.18.0
        ;;
   3.0) GTK_API_VERSION=3.0
        GTK_REQUIRED=2.90.4

--- a/src/entry.c
+++ b/src/entry.c
@@ -92,14 +92,14 @@ matedialog_entry (MateDialogData *data, MateDialogEntryData *entry_data)
   n_entries = g_slist_length (entries);
 
   if (n_entries > 1) {
-    entry = gtk_combo_box_entry_new_text ();
+    entry = gtk_combo_box_text_new_with_entry ();
 
     for (tmp = entries; tmp; tmp = tmp->next) {
-      gtk_combo_box_append_text (GTK_COMBO_BOX (entry), tmp->data);
+      gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (entry), tmp->data);
     }
 
     if (entry_data->entry_text) {
-      gtk_combo_box_prepend_text (GTK_COMBO_BOX (entry), entry_data->entry_text);
+      gtk_combo_box_text_prepend_text (GTK_COMBO_BOX_TEXT (entry), entry_data->entry_text);
       gtk_combo_box_set_active (GTK_COMBO_BOX (entry), 0);
     }
 
@@ -145,7 +145,7 @@ matedialog_entry_dialog_response (GtkWidget *widget, int response, gpointer data
     case GTK_RESPONSE_OK:
       zen_data->exit_code = matedialog_util_return_exit_code (MATEDIALOG_OK);
       if (n_entries > 1) {
-        text = gtk_combo_box_get_active_text (GTK_COMBO_BOX (entry));
+        text = gtk_combo_box_text_get_active_text (GTK_COMBO_BOX_TEXT (entry));
       }
       else {
         text = gtk_entry_get_text (GTK_ENTRY (entry));      

--- a/src/entry.c
+++ b/src/entry.c
@@ -92,14 +92,26 @@ matedialog_entry (MateDialogData *data, MateDialogEntryData *entry_data)
   n_entries = g_slist_length (entries);
 
   if (n_entries > 1) {
-    entry = gtk_combo_box_text_new_with_entry ();
+    #if GTK_CHECK_VERSION(2,24,0)
+      entry = gtk_combo_box_text_new_with_entry ();
+    #else
+      entry = gtk_combo_box_entry_new_text ();
+    #endif
 
     for (tmp = entries; tmp; tmp = tmp->next) {
-      gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (entry), tmp->data);
+      #if GTK_CHECK_VERSION(2,24,0)
+        gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (entry), tmp->data);
+      #else
+        gtk_combo_box_append_text (GTK_COMBO_BOX (entry), tmp->data);
+      #endif
     }
 
     if (entry_data->entry_text) {
-      gtk_combo_box_text_prepend_text (GTK_COMBO_BOX_TEXT (entry), entry_data->entry_text);
+      #if GTK_CHECK_VERSION(2,24,0)
+        gtk_combo_box_text_prepend_text (GTK_COMBO_BOX_TEXT (entry), entry_data->entry_text);
+      #else
+        gtk_combo_box_prepend_text (GTK_COMBO_BOX (entry), entry_data->entry_text);
+      #endif
       gtk_combo_box_set_active (GTK_COMBO_BOX (entry), 0);
     }
 
@@ -145,7 +157,11 @@ matedialog_entry_dialog_response (GtkWidget *widget, int response, gpointer data
     case GTK_RESPONSE_OK:
       zen_data->exit_code = matedialog_util_return_exit_code (MATEDIALOG_OK);
       if (n_entries > 1) {
-        text = gtk_combo_box_text_get_active_text (GTK_COMBO_BOX_TEXT (entry));
+        #if GTK_CHECK_VERSION(2,24,0)
+          text = gtk_combo_box_text_get_active_text (GTK_COMBO_BOX_TEXT (entry));
+        #else
+          text = gtk_combo_box_get_active_text (GTK_COMBO_BOX (entry));
+        #endif
       }
       else {
         text = gtk_entry_get_text (GTK_ENTRY (entry));      

--- a/src/util.c
+++ b/src/util.c
@@ -389,9 +389,13 @@ matedialog_util_make_transient (GdkWindow *window)
 {
   Window xterm = transient_get_xterm_toplevel ();
   if (xterm != None) {
-    GdkWindow *gdkxterm = gdk_x11_window_foreign_new_for_display (
-                        gdk_display_get_default (),
-                        xterm);
+    #if GTK_CHECK_VERSION(2,24,0)
+      GdkWindow *gdkxterm = gdk_x11_window_foreign_new_for_display (
+                          gdk_display_get_default (),
+                          xterm);
+    #else
+      GdkWindow *gdkxterm = gdk_window_foreign_new (xterm);
+    #endif
     if (gdkxterm) {
       gdk_window_set_transient_for (window, gdkxterm);
       g_object_unref (G_OBJECT (gdkxterm));

--- a/src/util.c
+++ b/src/util.c
@@ -389,7 +389,9 @@ matedialog_util_make_transient (GdkWindow *window)
 {
   Window xterm = transient_get_xterm_toplevel ();
   if (xterm != None) {
-    GdkWindow *gdkxterm = gdk_window_foreign_new (xterm);
+    GdkWindow *gdkxterm = gdk_x11_window_foreign_new_for_display (
+                        gdk_display_get_default (),
+                        xterm);
     if (gdkxterm) {
       gdk_window_set_transient_for (window, gdkxterm);
       g_object_unref (G_OBJECT (gdkxterm));


### PR DESCRIPTION
If I did it correctly, there should be no warning caused by
-DG_DISABLE_DEPRECATED
-DG_DISABLE_SINGLE_INCLUDES
-DGDK_DISABLE_DEPRECATED
-DGTK_DISABLE_DEPRECATED
-DGDK_DISABLE_SINGLE_INCLUDES
-DGTK_DISABLE_SINGLE_INCLUDES
now.

According to documentation the new functions used in this commit need GTK 2.24 so I bumped the requirement in configure.in . If this is not desired, I can make an additional commit that use version check macros to support older GTK versions.

A test case for changed code would be:
$ matedialog --entry foo bar
